### PR TITLE
Update for Juttle 0.5.0.

### DIFF
--- a/lib/aws/AWSMon.js
+++ b/lib/aws/AWSMon.js
@@ -2,7 +2,9 @@
 var jsdiff = require('diff');
 var _ = require('underscore');
 var traverse = require('traverse');
-var JuttleMoment = require('juttle/lib/moment/juttle-moment');
+
+/* global JuttleAdapterAPI */
+var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
 
 class AWSMon {
 

--- a/lib/filter-aws-compiler.js
+++ b/lib/filter-aws-compiler.js
@@ -4,8 +4,8 @@
 //
 // The expression is returned from the compile method.
 
-var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
-var JuttleErrors = require('juttle/lib/errors');
+/* global JuttleAdapterAPI */
+let StaticFilterCompiler = JuttleAdapterAPI.compiler.StaticFilterCompiler;
 var _ = require('underscore');
 
 // FilterAWSCompiler derives from ASTVisitor which provides a way to
@@ -29,42 +29,27 @@ var _ = require('underscore');
 //                 adapter fetches information for both sets of
 //                 products.
 
-var FilterAWSCompiler = ASTVisitor.extend({
-    initialize: function(options) {
+class FilterAWSCompiler extends StaticFilterCompiler {
+
+    constructor(options) {
+        super(options);
         this.cloudwatch = options.cloudwatch;
         this.supported_products = options.supported_products;
-    },
+    }
 
-    throwUnsupportedFilter(location, filter) {
-        throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER', {
-            proc: 'read cloudwatch',
-            filter: filter,
-            location: location
-        });
-    },
-
-    compile: function(node) {
+    compile(node) {
         return this.visit(node);
-    },
+    }
 
-    visitStringLiteral: function(node) {
+    visitStringLiteral(node) {
         return node.value;
-    },
+    }
 
-    visitUnaryExpression: function(node) {
-        switch (node.operator) {
-            // '*' is the field dereferencing operator. For example,
-            // given a search string product = 'CloudWatch', the UnaryExpression
-            // * on product means 'the field called product'.
-            case '*':
-                return this.visit(node.expression);
+    visitField(node) {
+        return node.name;
+    }
 
-            default:
-                this.throwUnsupportedFilter(node.location, 'operator ' + node.operator);
-        }
-    },
-
-    visitBinaryExpression: function(node) {
+    visitBinaryExpression(node) {
         var left, right;
 
         switch (node.operator) {
@@ -82,23 +67,19 @@ var FilterAWSCompiler = ASTVisitor.extend({
                 // Left *must* be 'product', and right must be one of
                 // the supported AWS products.
                 if (left !== 'product') {
-                    this.throwUnsupportedFilter(node.location, 'condition ' + left);
+                    this.featureNotSupported(node, 'condition ' + left);
                 }
 
                 if (! _.contains(this.supported_products, right)) {
-                    this.throwUnsupportedFilter(node.location, 'product ' + right);
+                    this.featureNotSupported(node, 'product ' + right);
                 }
 
                 return [right];
 
             default:
-                this.throwUnsupportedFilter(node.location, 'operator ' + node.operator);
+                this.featureNotSupported(node, 'operator ' + node.operator);
         }
-    },
-
-    visitExpressionFilterTerm: function(node) {
-        return this.visit(node.expression);
     }
-});
+}
 
 module.exports = FilterAWSCompiler;

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,15 +1,18 @@
 'use strict';
+
+/* global JuttleAdapterAPI */
+var AdapterRead = JuttleAdapterAPI.AdapterRead;
+var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+var FilterAWSCompiler = require('./filter-aws-compiler');
+
 var AWSFactory = require('./aws/Factory');
-var AdapterRead = require('juttle/lib/runtime/adapter-read');
 var Promise = require('bluebird');
 var _ = require('underscore');
-var FilterAWSCompiler = require('./filter-aws-compiler');
-var JuttleMoment = require('juttle/lib/moment/juttle-moment');
 
 class ReadAWS extends AdapterRead {
     periodicLiveRead() { return true;}
 
-    defaultTimeRange() {
+    defaultTimeOptions() {
         return {
             from: this.params.now,
             to: new JuttleMoment(Infinity)
@@ -20,6 +23,13 @@ class ReadAWS extends AdapterRead {
         super(options, params);
 
         this.logger.debug('intitialize', options, params);
+
+        if (options.from.lt(params.now)) {
+            throw this.compileError('ADAPTER-UNSUPPORTED-TIME-OPTION', {
+                option: '-from',
+                message: 'can not be before :now:'
+            });
+        }
 
         this._filter_search_expr = AWSFactory.supported_products();
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4"
   },
+  "juttleAdapterAPI": "^0.5.0",
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"

--- a/test/filter-aws-compiler.spec.js
+++ b/test/filter-aws-compiler.spec.js
@@ -1,107 +1,116 @@
 'use strict';
+
 var JuttleParser = require('juttle/lib/parser');
 var SemanticPass = require('juttle/lib/compiler/semantic');
-var JuttleErrors = require('juttle/lib/errors');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
-var FilterAWSCompiler = require('../lib/filter-aws-compiler');
+var FilterSimplifier = require('juttle/lib/compiler/filters/filter-simplifier');
 var expect = require('chai').expect;
+let withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
 
-function verify_compile_error(source, filter) {
-    var ast = JuttleParser.parseFilter(source).ast;
+withAdapterAPI(() => {
 
-    var semantic = new SemanticPass({ now: new JuttleMoment() });
-    semantic.sa_expr(ast);
+    /* global JuttleAdapterAPI */
+    let JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+    let JuttleErrors = JuttleAdapterAPI.errors;
+    let FilterAWSCompiler = require('../lib/filter-aws-compiler');
+    let simplifier = new FilterSimplifier();
 
-    var compiler = compiler || new FilterAWSCompiler({
-        supported_products: ['EC2', 'EBS']
-    });
+    function verify_compile_error(source, feature) {
+        var ast = JuttleParser.parseFilter(source).ast;
 
-    try {
-        compiler.compile(ast);
-    } catch (e) {
-        expect(e).to.be.instanceOf(JuttleErrors.CompileError);
-        expect(e.code).to.equal('RT-ADAPTER-UNSUPPORTED-FILTER');
-        expect(e.info.filter).to.equal(filter);
+        var semantic = new SemanticPass({ now: new JuttleMoment() });
+        semantic.sa_expr(ast);
+
+        ast = simplifier.simplify(ast);
+
+        var compiler = compiler || new FilterAWSCompiler({
+            supported_products: ['EC2', 'EBS']
+        });
+
+        try {
+            compiler.compile(ast);
+            throw new Error('Compile succeeded when it should have failed');
+        } catch (e) {
+            expect(e).to.be.instanceOf(JuttleErrors.CompileError);
+            expect(e.code).to.equal('FILTER-FEATURE-NOT-SUPPORTED');
+            expect(e.info.feature).to.equal(feature);
+        }
     }
-}
 
-function verify_compile_success(source, expected) {
-    var ast = JuttleParser.parseFilter(source).ast;
+    function verify_compile_success(source, expected) {
+        var ast = JuttleParser.parseFilter(source).ast;
 
-    var semantic = new SemanticPass({ now: new JuttleMoment() });
-    semantic.sa_expr(ast);
+        var semantic = new SemanticPass({ now: new JuttleMoment() });
+        semantic.sa_expr(ast);
 
-    var compiler = new FilterAWSCompiler({
-        supported_products: ['EC2', 'EBS']
-    });
+        ast = simplifier.simplify(ast);
 
-    var search_expr = compiler.compile(ast);
-    expect(search_expr).to.deep.equal(expected);
-}
+        var compiler = new FilterAWSCompiler({
+            supported_products: ['EC2', 'EBS']
+        });
 
-describe('aws filter', function() {
+        var search_expr = compiler.compile(ast);
+        expect(search_expr).to.deep.equal(expected);
+    }
 
-    describe(' properly returns errors for invalid filtering expressions like ', function() {
+    describe('aws filter', function() {
 
-        var invalid_unary_operators = ['!', '-'];
+        describe('properly returns errors for invalid filtering expressions like', function() {
 
-        invalid_unary_operators.forEach(function(op) {
-            it('using unary operator ' + op + ' in field specifications', function() {
-                verify_compile_error('product = ' + op + ' "foo"',
-                                     'operator ' + op);
+            var invalid_unary_operators = ['!', '-'];
+
+            for(let op of invalid_unary_operators) {
+                it('using unary operator ' + op + ' in field specifications', function() {
+                    verify_compile_error('product = ' + op + ' "foo"',
+                                         `the "${op}" operator`);
+                });
+            }
+
+            var invalid_operators = ['=~', '!~', '<', '<=', '>', '>=', 'in'];
+            for(let op of invalid_operators) {
+                it('using ' + op + ' in field comparisons', function() {
+                    verify_compile_error('product ' + op + ' "foo"',
+                                         'operator ' + op);
+                });
+            }
+
+            it('Combining terms with AND', function() {
+                verify_compile_error('product="EC2" AND product="EBS"',
+                                     'operator AND');
+            });
+
+            it('Using NOT on a term', function() {
+                verify_compile_error('NOT product="EC2"',
+                                     'the "NOT" operator');
+            });
+
+            it('A filter term not containing "product"', function() {
+                verify_compile_error('foo="EC2"',
+                                     'condition foo');
+            });
+
+            it('matching on unsupported products', function() {
+                verify_compile_error('product = "RDS"',
+                                     'product RDS');
+            });
+
+            it('a single filter expression', function() {
+                verify_compile_error('\"foo\"',
+                                     'fulltext search');
             });
         });
 
-        var invalid_operators = ['=~', '!~', '<', '<=', '>', '>=', 'in'];
-        invalid_operators.forEach(function(op) {
-            it('using ' + op + ' in field comparisons', function() {
-                verify_compile_error('product ' + op + ' "foo"',
-                                     'operator ' + op);
+        describe('properly returns condition lists for valid cases like', function() {
+            it('Single product match', function() {
+                verify_compile_success('product="EC2"', ['EC2']);
             });
-        });
 
-        it('Combining terms with AND', function() {
-            verify_compile_error('product="EC2" AND product="EBS"',
-                                 'operator AND');
-        });
+            it('Multiple product matches', function() {
+                verify_compile_success('product="EC2" OR product="EBS"', ['EC2', 'EBS']);
+            });
 
-        it('Using NOT on a term', function() {
-            verify_compile_error('NOT product="EC2"',
-                                 'operator NOT');
-        });
-
-        it('A filter term not containing "product"', function() {
-            verify_compile_error('foo="EC2"',
-                                 'condition foo');
-        });
-
-        it('matching on unsupported products', function() {
-            verify_compile_error('product = "RDS"',
-                                 'product RDS');
-        });
-
-        it('a single filter expression', function() {
-            verify_compile_error('\"foo\"',
-                                 'filter term UnaryExpression');
-        });
-
-        it('not a filter expression or string', function() {
-            verify_compile_error('+ 1',
-                                 'operator +');
-        });
-    });
-
-    describe(' properly returns condition lists for valid cases like ', function() {
-        it('Single product match', function() {
-            verify_compile_success('product="EC2"', ['EC2']);
-        });
-
-        it('Multiple product matches', function() {
-            verify_compile_success('product="EC2" OR product="EBS"', ['EC2', 'EBS']);
-        });
-
-        it('Multiple product matches w/ duplicates', function() {
-            verify_compile_success('product="EC2" OR product="EC2"', ['EC2']);
+            it('Multiple product matches w/ duplicates', function() {
+                verify_compile_success('product="EC2" OR product="EC2"', ['EC2']);
+            });
         });
     });
 });


### PR DESCRIPTION
Access AdapterRead, JuttleMoment, StaticFilterCompiler etc through
JuttleAdapterAPI.

Use ES6 class for FilterAWSCompiler derived from StaticFilterCompiler.

Use already-provided featureNotSupported to return errors.

Update filter parsing callbacks based on the advice in
https://github.com/juttle/juttle/wiki/Porting-Adapters-to-the-0.5.x-API.

Create the adapter in the test as suggested.

Fix a false negative problem in the tests where one of the programs
that should have returned an error was falsely succeeding (-from
before :now:). And then add a check in the constructor to fix that.

-from :now: -to :now: isn't supported any longer, so replace it with
 -from :now: -to :1 second from now: to get a single read.

Note the juttleAdapterAPI dependency in package.json.

@VladVega @demmer @davidvgalbraith 