### PR TITLE
Change default timerange.

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -14,8 +14,8 @@ class ReadAWS extends AdapterRead {
 
     defaultTimeOptions() {
         return {
-            from: this.params.now,
-            to: new JuttleMoment(Infinity)
+            from: new JuttleMoment({moment: this.params.now.moment.clone(), epsilon: true}),
+            to: this.params.now
         };
     }
 
@@ -24,7 +24,7 @@ class ReadAWS extends AdapterRead {
 
         this.logger.debug('intitialize', options, params);
 
-        if (options.from.lt(params.now)) {
+        if (_.has(options, 'from') && options.from.lt(params.now)) {
             throw this.compileError('ADAPTER-UNSUPPORTED-TIME-OPTION', {
                 option: '-from',
                 message: 'can not be before :now:'

--- a/test/aws-adapter.spec.js
+++ b/test/aws-adapter.spec.js
@@ -133,7 +133,7 @@ describe('aws adapter', function() {
 
         it('basic info', function() {
             return check_juttle({
-                program: 'read aws -from :now: -to :1 second from now: | view text'
+                program: 'read aws | view text'
             })
             .then(function(result) {
                 expect(result.errors).to.have.length(0);
@@ -148,7 +148,7 @@ describe('aws adapter', function() {
             let aws_module_path = path.join(__dirname, '../aws_module.juttle');
             let awsmod = fs.readFileSync(aws_module_path).toString();
             return check_juttle({
-                program: `import "aws_module.juttle" as AWSMod; read aws -from :now: -to :1 second from now: | AWSMod.aggregate_all | view text`,
+                program: `import "aws_module.juttle" as AWSMod; read aws | AWSMod.aggregate_all | view text`,
                 modules: {
                     'aws_module.juttle': awsmod
                 }


### PR DESCRIPTION
Instead of having the default timerange be from :now: to :end:, change
the default to be from :now: - epsilon to :now. This does change when
someone has to specify a -from/-to for the two common use cases of a
one-shot read vs reading live indefinitely, but it's easier to just
add a -to :end: than add a -to :1 second from now:, so that's a bit
more compact.

@demmer 