### PR TITLE
Add ecosystem link to juttle-aws-adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ $ npm install juttle-aws-adapter
 
 ## Ecosystem
 
-Here's how the juttle-aws-adapter module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+The juttle-aws-adapter fits into the overall Juttle Ecosystem as one of the adapters in the [below diagram](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
 
 [![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ the adapter need to be installed side-by-side:
 $ npm install juttle
 $ npm install juttle-aws-adapter
 ```
+
+## Ecosystem
+
+Here's how the juttle-aws-adapter module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+
+[![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
+
 ## Configuration
 
 Configuration involves these steps:


### PR DESCRIPTION
Add an ecosystem section to each README to show its part in the
overall architecture.

@davidvgalbraith  @dmehra 