### PR TITLE
Prepare for 0 7 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 This file documents all notable changes to juttle-aws-adapter. The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.3.0
+Released 2016-03-23
+
+### Minor Changes
+- Updated to be compatible with Juttle 0.7.x. [[#12](https://github.com/juttle/juttle-aws-adapter/pull/12)].
+- Include juttle programs that perform aggregations in the adapter, so they can be used as [adapter modules](https://github.com/juttle/juttle/blob/master/docs/adapters/adapter_api.md#Adapter%20Modules) [[#13](https://github.com/juttle/juttle-aws-adapter/issues/13)]
+
 ## 0.2.1
 Released 2016-03-01
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The adapter supports the following AWS Products:
 
 By default, the adapter returns the raw json results of the AWS API calls for each product's "list items" function (e.g. `EC2.describeInstances`, `ELB.describeLoadBalancers`, etc) as Juttle points. The adapter also monitors the active set of items (EC2 Instances, etc) for each product and emits events when the items change. For example, when a new EC2 instance is added, a "EC2 instance added" event is generated. Also, when anything related to a given item is changed, a "... changed" event is generated.
 
-The `aws` module packaged with the adapter exports several [subgraphs](http://juttle.github.io/juttle/concepts/programming_constructs/#subgraphs) that can be included in Juttle programs to automatically summarize the raw points returned from the AWS API calls. Each product has an `aggregate_all_<product>()` subgraph that summarizes points associated with each product. Additionally, there is an `aggregate_all` subgraph that summarizes for all products.
+The module packaged with the adapter, which can be imported via `import "adapters/aws"`, exports several [subgraphs](http://juttle.github.io/juttle/concepts/programming_constructs/#subgraphs) that can be included in Juttle programs to automatically summarize the raw points returned from the AWS API calls. Each product has an `aggregate_all_<product>()` subgraph that summarizes points associated with each product. Additionally, there is an `aggregate_all` subgraph that summarizes for all products.
 
 The subgraphs summarize the raw points into the following categories.
 - **Demographic Information**: for each product, breakdowns by size, storage class, memory software version, etc.
@@ -39,8 +39,10 @@ The AWS Adapter is very closely related to the [Juttle Cloudwatch Adapter](https
 ## Examples
 
 ```
+import 'adapters/aws' as AWS;
+
 read aws product='EC2'
-    | Adapter.aws.aggregate_EC2
+    | AWS.aggregate_EC2
     | filter demographic='EC2 Instance Type'
     | keep demographic, name, value
     | view table

--- a/juttle/index.juttle
+++ b/juttle/index.juttle
@@ -1,0 +1,185 @@
+// Categorize the points by the field with name 'cat_field'.
+sub add_demo(demo, field) {
+    reduce time=last(time), product=last(product), value=count(), demographic=demo, name=*field, metric_type='AWS Demographic' by field
+        | remove field;
+}
+
+// Aggregate the points by the field with name 'field' via a sum().
+sub add_agg(agg, field) {
+    reduce time=last(time), product=last(product), value=sum(field), aggregate=agg, name='total', metric_type='AWS Aggregate';
+}
+
+// We filter by product both before and after as the reduce()s will
+// return 0 counts when there are no points.  Also, the aggregations
+// use a very short batch window of 1 second. This works because the
+// adapter assigns the same timestamp to all points for a given call
+// to poll().
+export sub aggregate_AutoScaling() {
+    filter product='AutoScaling'
+    | (
+        // Let all events through
+        filter event_type ~ "*";
+
+        // For non-events, perform these aggregations
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                         | add_agg  -agg 'AutoScaling Group Count'                  -field 'one';
+            put len=Array.length(Instances)   | add_agg  -agg 'AutoScaling Group Total Size'             -field 'len';
+                                                add_agg  -agg 'AutoScaling Group Total Desired Capacity' -field 'DesiredCapacity';
+                                                add_demo -demo 'AutoScaling Desired Capacity'            -field 'DesiredCapacity';
+            put len = Array.length(Instances) | add_demo -demo 'AutoScaling Current Group Size'          -field 'len';
+                                                add_demo -demo 'AutoScaling Health Check Type'           -field 'HealthCheckType';
+        )
+      )
+    | filter product='AutoScaling'
+}
+
+export sub aggregate_CloudFront() {
+    filter product='CloudFront'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                                | add_agg  -agg 'CF Distribution Count' -field 'one';
+                                                       add_demo -demo 'CF Status'            -field 'Status';
+            put pclass=DistributionConfig.PriceClass | add_demo -demo 'CF Price Class'       -field 'pclass';
+            put enabled=DistributionConfig.Enabled   | add_demo -demo 'CF Enabled' -field 'enabled';
+        )
+    )
+    | filter product='CloudFront'
+}
+
+export sub aggregate_EBS() {
+    filter product='EBS'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                           | add_agg  -agg 'EBS Volume Count'           -field 'one';
+                                                  add_agg  -agg 'EBS Volume Total Size'      -field 'Size';
+                                                  add_agg  -agg 'EBS Volume Total Iops'      -field 'Iops';
+                                                  add_demo -demo 'EBS Volume State'          -field 'State';
+                                                  add_demo -demo 'EBS Volume Type'           -field 'VolumeType';
+            put status = VolumeStatus.Status    | add_demo -demo 'EBS Volume Status'         -field 'status';
+        )
+    )
+    | filter product='EBS'
+}
+
+export sub aggregate_EC2() {
+    filter product='EC2'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1               | add_agg  -agg 'EC2 Instance Count'    -field 'one';
+                                      add_demo -demo 'EC2 Instance Type'    -field 'InstanceType';
+            put state=State.Name    | add_demo -demo 'EC2 State'            -field 'state';
+                                      add_demo -demo 'EC2 Root Device Type' -field 'RootDeviceType';
+        )
+      )
+    | filter product='EC2'
+}
+
+export sub aggregate_ELB() {
+    filter product='ELB'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                        | add_agg  -agg 'ELB Load Balancer Count'   -field 'one';
+                                               add_demo -demo 'ELB Scheme'               -field 'Scheme';
+            put target=HealthCheck.Target    | add_demo -demo 'ELB Health Check Target'  -field 'target';
+        )
+    )
+    | filter product='ELB'
+}
+
+export sub aggregate_ElastiCache() {
+    filter product='ElastiCache'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                        | add_agg  -agg 'ElastiCache Cluster Count'      -field 'one';
+                                               add_agg  -agg 'ElastiCache Total Cache Nodes'  -field 'NumCacheNodes';
+                                               add_demo -demo 'ElastiCache Cache Node Type'   -field 'CacheNodeType';
+                                               add_demo -demo 'ElastiCache Engine'            -field 'Engine';
+                                               add_demo -demo 'ElastiCache Cluster Status'    -field 'CacheClusterStatus';
+                                               add_demo -demo 'ElastiCache Num Cache Nodes'   -field 'NumCacheNodes';
+                                               add_demo -demo 'ElastiCache Engine Version'    -field 'EngineVersion';
+        )
+    )
+    | filter product='ElastiCache'
+}
+
+export sub aggregate_Lambda() {
+    filter product='Lambda'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                        | add_agg  -agg 'Lambda Function Count'          -field 'one';
+                                               add_agg  -agg 'Lambda Total Memory Size'       -field 'MemorySize';
+                                               add_demo -demo 'Lambda Runtime'                -field 'Runtime';
+                                               add_demo -demo 'Lambda Role'                   -field 'Role';
+                                               add_demo -demo 'Lambda Timeout'                -field 'Timeout';
+                                               add_demo -demo 'Lambda Memory Size'            -field 'MemorySize';
+                                               add_demo -demo 'Lambda Version'                -field 'Version';
+                                               add_demo -demo 'Lambda Handler'                -field 'Handler';
+        )
+    )
+    | filter product='Lambda'
+}
+
+function getReplicaStatus(StatusInfos) {
+    if (Array.length(StatusInfos) == 0) {
+        return 'Not Read Replica';
+    } else {
+        return StatusInfos[0].Status;
+    }
+}
+
+export sub aggregate_RDS() {
+    filter product='RDS'
+    | (
+        filter event_type ~ "*";
+        filter event_type !~ "*"
+        |  batch -every :1s:
+        | (
+            put one=1                                        | add_agg  -agg 'RDS DB Count'                      -field 'one';
+                                                               add_agg  -agg 'RDS DB Total Allocated Storage'    -field 'AllocatedStorage';
+                                                               add_agg  -agg 'RDS DB Total Iops'                 -field 'Iops';
+                                                               add_demo -demo 'RDS DB Class'                     -field 'DBInstanceClass';
+                                                               add_demo -demo 'RDS DB Engine'                    -field 'Engine';
+                                                               add_demo -demo 'RDS DB Engine Version'            -field 'EngineVersion';
+                                                               add_demo -demo 'RDS DB License Model'             -field 'LicenseModel';
+                                                               add_demo -demo 'RDS DB Retention Period'          -field 'BackupRetentionPeriod';
+                                                               add_demo -demo 'RDS DB PubliclyAccessible'        -field 'PubliclyAccessible';
+                                                               add_demo -demo 'RDS DB Storage Type'              -field 'StorageType';
+                                                               add_demo -demo 'RDS DB Status'                    -field 'DBInstanceStatus';
+            put replica_status=getReplicaStatus(StatusInfos) | add_demo -demo 'RDS DB Read Replica Status'       -field 'replica_status';
+        )
+    )
+    | filter product='RDS'
+}
+
+export sub aggregate_all () {
+    (
+        aggregate_AutoScaling;
+        aggregate_CloudFront;
+        aggregate_EBS;
+        aggregate_EC2;
+        aggregate_ELB;
+        aggregate_ElastiCache;
+        aggregate_Lambda;
+        aggregate_RDS;
+    )
+}

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4"
   },
-  "juttleAdapterAPI": "^0.5.3",
+  "juttleAdapterAPI": "^0.7.0",
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4"
   },
-  "juttleAdapterAPI": "^0.5.0",
+  "juttleAdapterAPI": "^0.5.3",
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"

--- a/test/aws-adapter.spec.js
+++ b/test/aws-adapter.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 var _ = require('underscore');
 var path = require('path');
-var fs = require('fs');
 var juttle_test_utils = require('juttle/test').utils;
 var check_juttle = juttle_test_utils.check_juttle;
 var expect = require('chai').expect;
@@ -145,13 +144,9 @@ describe('aws adapter', function() {
         });
 
         it('aggregate info', function() {
-            let aws_module_path = path.join(__dirname, '../aws_module.juttle');
-            let awsmod = fs.readFileSync(aws_module_path).toString();
             return check_juttle({
-                program: `import "aws_module.juttle" as AWSMod; read aws | AWSMod.aggregate_all | view text`,
-                modules: {
-                    'aws_module.juttle': awsmod
-                }
+                program: `import "adapters/aws" as AWS; read aws product="RDS"| AWS.aggregate_all | view text`,
+                moduleResolver: juttle_test_utils.module_resolver({})
             })
             .then(function(result) {
                 expect(result.errors).to.have.length(0);


### PR DESCRIPTION
Make changes necessary to support juttle 0.7.0. This is mostly just switching to adapter modules, but the juttle for the module also required minor changes for nested point support.

There's a current test failure I don't understand. Two test cases related to unary expressions are passing now when they should be failing. @dmajda can you take a look?

This fixes #13.
